### PR TITLE
Custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ Then make a new issue that something is wrong:
 
 ```
 % ./autocut -owner allenai -repo aimichal -dur 10m -title "something is wrong" -details "bad habits"
-Opened new issue https://github.com/allenai/aimichal/issues/27.
+{opened new issue https://github.com/allenai/aimichal/issues/27}
 ```
 
 Any time in the next 10 minutes, repeating this will do nothing:
 
 ```
 % ./autocut -owner allenai -repo aimichal -dur 10m -title "something is wrong" -details "bad habits"
-Found recently updated issue, so did nothing: https://github.com/allenai/aimichal/issues/27
+{found recently updated issue, so did nothing https://github.com/allenai/aimichal/issues/27}
 ```
 
 But after 10 minutes, running this will update the issue with a comment:
 
 ```
 % ./autocut -owner allenai -repo aimichal -dur 10m -title "something is wrong" -details "such bad things are happening"
-Found a stale issue, so commented on it: https://github.com/allenai/aimichal/issues/27
+{found a stale issue, so commented on it https://github.com/allenai/aimichal/issues/27}
 ```
 
 If this issue is closed, then running this will re-open the issue within 10

--- a/autocut.go
+++ b/autocut.go
@@ -41,7 +41,7 @@ const (
 
 const autocutLabel = "autocut"
 
-func (ac *Autocut) Cut(ctx context.Context, title, details string) (CutResult, error) {
+func (ac *Autocut) Cut(ctx context.Context, title, details string, customLabels []string) (CutResult, error) {
 	issues := ac.getIssues(ctx)
 	result, matched := ac.firstMatch(issues, title)
 
@@ -78,7 +78,7 @@ func (ac *Autocut) Cut(ctx context.Context, title, details string) (CutResult, e
 			IssueURL: matched.GetHTMLURL(),
 		}, nil
 	case foundNone:
-		newIss, err := ac.create(ctx, title, details)
+		newIss, err := ac.create(ctx, title, details, customLabels)
 		if err != nil {
 			return CutResult{None, ""}, err
 		}
@@ -167,11 +167,14 @@ func (ac *Autocut) reopen(ctx context.Context, issNumber int) error {
 	return nil
 }
 
-func (ac *Autocut) create(ctx context.Context, title, body string) (*github.Issue, error) {
+func (ac *Autocut) create(ctx context.Context, title, body string, customLabels []string) (*github.Issue, error) {
+	labels := []string{autocutLabel}
+	labels = append(labels, customLabels...)
+
 	iss, _, err := ac.Client.Issues.Create(ctx, ac.Owner, ac.Repo, &github.IssueRequest{
 		Title:  &title,
 		Body:   &body,
-		Labels: &[]string{autocutLabel},
+		Labels: &labels,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Custom labels can be provided with the new "-labels" arg. For example, invoking with `-labels "a,b/c,dee ee eff"` causes three labels to be added: `a`, `b/c`, and `dee ee eff`.
